### PR TITLE
Configure sandbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,7 +13,12 @@ console.log('Launch script...');
 
 Apify.main(async () => {
     console.log('Launching Puppeteer...');
-    const browser = await Apify.launchPuppeteer();
+    const browser = await Apify.launchPuppeteer({
+      launchOptions: {
+          headless: false
+          //,args: ['--no-sandbox']
+      }
+    });
 
     const page = await browser.newPage();
 

--- a/main.js
+++ b/main.js
@@ -11,14 +11,16 @@ const moment = require('moment');
 
 console.log('Launch script...');      
 
+const isV1 = typeof Apify.launchPuppeteer === 'function';
+
 Apify.main(async () => {
     console.log('Launching Puppeteer...');
-    const browser = await Apify.launchPuppeteer({
-      launchOptions: {
-          headless: false
-          //,args: ['--no-sandbox']
-      }
-    });
+
+    // We need --no-sandbox, for app running in Docker.
+    const launchOptions = { headless: true, args: ['--no-sandbox'] };
+    const launchContext = isV1 ? { launchOptions } : launchOptions;
+
+    const browser = await Apify.launchPuppeteer(launchContext);
 
     const page = await browser.newPage();
 
@@ -43,7 +45,7 @@ Apify.main(async () => {
     console.log(result.text())
 
     // Wait 30s to see Chromium works :)
-    await new Promise(resolve => setTimeout(resolve, 20000));
+    await new Promise(resolve => setTimeout(resolve, 200));
 
     await browser.close();
 });

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export APIFY_LOCAL_STORAGE_DIR='/apify_storage'
 node main.js


### PR DESCRIPTION
- enable docker mode
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/18621691/180647612-c174d9dc-33ee-4f77-a31e-cc0ddcc5f7bf.png">
- servers don't have monitors so they usually don't run GUI (X server) so they can't display windows and you have to use `headless : true`

https://stackoverflow.com/questions/71512269/puppeteer-in-headless-false-mode-on-ubuntu-error


TODO:
- fixes 
<img width="709" alt="image" src="https://user-images.githubusercontent.com/18621691/180647588-7ab51cb9-104b-4fa7-9299-9f4699e44ed4.png">
- run apify local vs docker mode
